### PR TITLE
Composition lemmas

### DIFF
--- a/Is0/Lemmas.lean
+++ b/Is0/Lemmas.lean
@@ -41,12 +41,9 @@ lemma run_eqz (x : Felt) (h₁ : st.felts ⟨name⟩ = some x) :
 
 lemma run_composes (program_halves: program = (first_half; second_half)) :
   MLIR.runProgram program start_state = MLIR.runProgram second_half (MLIR.runProgram first_half start_state) := by
-  rewrite [program_halves]
-  unfold runProgram
-  simp [run_seq_def]
+  simp [program_halves, run_seq_def]
 
 lemma seq_associative : MLIR.runProgram (p₁; (p₂; p₃)) state = MLIR.runProgram ((p₁; p₂); p₃) state := by
-  unfold runProgram run
   simp [run_seq_def]
 
 end MLIR


### PR DESCRIPTION
Two lemmas introduced:

- run_composes which shows that MLIR.runProgram can be applied to subPrograms individually
- seq_associative which is intended to be used to allow programs to be split into meaningful subPrograms