### PR TITLE
Fix get/back implementations

### DIFF
--- a/Risc0/Basic.lean
+++ b/Risc0/Basic.lean
@@ -303,9 +303,12 @@ def Op.eval {x} (st : State) (op : Op x) : Option Lit :=
             else (st.props inner).get!
     -- Buffers
     | Alloc size          => .some <| .Buf <| List.replicate size 0
-    | Back buf back       => .some <| .Buf <| (List.get! (st.buffers buf).get! (st.cycle - 1)).slice 0 back
-    | Get buf back offset => if st.cycle ≤ back ∧ offset < st.bufferWidths[buf].get! -- TODO(review): this is equivalent to throwing in Ops.cpp/GetOp::evaluate, right?
-                             then .some <| .Val <| (st.buffers buf).get!.get! ((st.cycle - 1) - back.toNat) |>.get! offset
+    | Back buf back       => .some <| .Buf <| (List.get! (st.buffers.get! buf) st.cycle).slice 0 back
+    | Get buf back offset => if
+                              back ≤ st.cycle ∧
+                              buf ∈ st.vars ∧
+                              offset < st.bufferWidths.get! buf
+                             then .some <| .Val <| (st.buffers.get! buf).get! (st.cycle - back.toNat) |>.get! offset
                              else .none          
     | GetGlobal buf idx   => .some <| .Val <| let buf' := st.buffers buf |>.get!
                                               let bufferWidth := st.bufferWidths buf |>.get!


### PR DESCRIPTION
Back should be less than or equal to cycle. At cycle 10, it's valid to go back 2 (or up to 10) steps
I don't think the -1s are necessary. Cycle 1 should be different from cycle 0, and neither should need a -1 as far as I can tell
Added a check for buf being in vars otherwise the op fails just to be explicit about it